### PR TITLE
Improve syntax highlighting and CSS handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 env_logger = "0.9"
-syntect = { version = "5.0", optional = true }
+syntect = { version = "5.3.0", optional = true }
 once_cell = { version = "1.13", optional = true }
 notify = { version = "4.0", optional = true }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -619,13 +619,14 @@ article ol {
 code,
 pre {
 	font-family: var(--fnt-family-mono);
-	background-color: var(--col-bg-dimmed);
 	border-radius: 2px;
 	font-size: 0.875em;
 }
 
-code {
+/* Inline code only */
+:not(pre) > code {
 	padding: 1px 7px;
+	background-color: var(--col-bg-dimmed);
 }
 
 pre {
@@ -637,20 +638,15 @@ pre {
 	display: block;
 	overflow: auto;
 	padding: 0.75rem 1rem;
-	/* Override Syntect's hardcoded inline background-color */
-	background-color: var(--col-bg-dimmed) !important;
+	background-color: var(--col-bg-dimmed);
 }
 
-/* In dark mode, mute Syntect's hardcoded text colours so they remain readable */
-@media (prefers-color-scheme: dark) {
-	pre[style] span {
-		color: var(--col-fg) !important;
-		font-weight: normal !important;
-	}
-}
-html[data-color-mode="dark"] pre[style] span {
-	color: var(--col-fg) !important;
-	font-weight: normal !important;
+/* Reset code element nested inside pre (e.g. from ClassedHTMLGenerator / hljs) */
+pre code {
+	background: none !important;
+	padding: 0;
+	border-radius: 0;
+	font-size: inherit;
 }
 
 /* --------------------------------- FOOTER ----------------------------------*/

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -32,6 +32,7 @@ pub use syntect_hl::SyntectHighlighter;
 mod syntect_hl {
     use std::io::Write;
 
+    use once_cell::sync::OnceCell;
     use pulldown_cmark::Event;
     use syntect::{
         highlighting::ThemeSet,
@@ -52,6 +53,7 @@ mod syntect_hl {
     pub struct SyntectHighlighter {
         ss: SyntaxSet,
         ts: ThemeSet,
+        header_cache: OnceCell<String>,
     }
 
     impl SyntectHighlighter {
@@ -60,6 +62,7 @@ mod syntect_hl {
             SyntectHighlighter {
                 ss: SyntaxSet::load_defaults_newlines(),
                 ts: ThemeSet::load_defaults(),
+                header_cache: OnceCell::new(),
             }
         }
     }
@@ -86,23 +89,28 @@ mod syntect_hl {
         }
 
         fn write_header(&self, out: &mut dyn Write) -> std::io::Result<()> {
-            let io_err =
-                |e: syntect::Error| std::io::Error::new(std::io::ErrorKind::Other, e.to_string());
-            let light_css = strip_background_color(
-                &css_for_theme_with_class_style(&self.ts.themes[LIGHT_THEME], class_style())
-                    .map_err(io_err)?,
-            );
-            let dark_css = strip_background_color(
-                &css_for_theme_with_class_style(&self.ts.themes[DARK_THEME], class_style())
-                    .map_err(io_err)?,
-            );
-            let dark_prefixed =
-                prefix_css_selectors(&dark_css, "html[data-color-mode=\"dark\"]");
-            write!(
-                out,
-                "<style>\n{}\n@media (prefers-color-scheme: dark) {{\n{}}}\n{}</style>",
-                light_css, dark_css, dark_prefixed
-            )
+            let header = self.header_cache.get_or_try_init(|| -> std::io::Result<String> {
+                let io_err = |e: syntect::Error| {
+                    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+                };
+                let light_css = strip_background_color(
+                    &css_for_theme_with_class_style(&self.ts.themes[LIGHT_THEME], class_style())
+                        .map_err(io_err)?,
+                );
+                let dark_css = strip_background_color(
+                    &css_for_theme_with_class_style(&self.ts.themes[DARK_THEME], class_style())
+                        .map_err(io_err)?,
+                );
+                let dark_auto =
+                    prefix_css_selectors(&dark_css, "html:not([data-color-mode])");
+                let dark_prefixed =
+                    prefix_css_selectors(&dark_css, "html[data-color-mode=\"dark\"]");
+                Ok(format!(
+                    "<style>\n{}\n@media (prefers-color-scheme: dark) {{\n{}}}\n{}</style>",
+                    light_css, dark_auto, dark_prefixed
+                ))
+            })?;
+            out.write_all(header.as_bytes())
         }
     }
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -21,7 +21,6 @@ pub(crate) trait Highlighter {
     fn hl_codeblock<'a>(&self, name: Option<&str>, block: &str) -> Vec<Event<'_>>;
 
     /// # Write any HTML header required for highlighting on this page.
-    #[allow(dead_code)]
     fn write_header(&self, out: &mut dyn Write) -> std::io::Result<()>;
 }
 
@@ -35,10 +34,20 @@ mod syntect_hl {
 
     use pulldown_cmark::Event;
     use syntect::{
-        self, highlighting::ThemeSet, html::highlighted_html_for_string, parsing::SyntaxSet,
+        highlighting::ThemeSet,
+        html::{css_for_theme_with_class_style, ClassStyle, ClassedHTMLGenerator},
+        parsing::SyntaxSet,
+        util::LinesWithEndings,
     };
 
     use super::{to_default_events, Highlighter};
+
+    const LIGHT_THEME: &str = "InspiredGitHub";
+    const DARK_THEME: &str = "base16-ocean.dark";
+
+    fn class_style() -> ClassStyle {
+        ClassStyle::SpacedPrefixed { prefix: "hl-" }
+    }
 
     pub struct SyntectHighlighter {
         ss: SyntaxSet,
@@ -48,30 +57,83 @@ mod syntect_hl {
     impl SyntectHighlighter {
         /// # Create a New Highlighter
         pub fn new() -> Self {
-            let ss = SyntaxSet::load_defaults_newlines();
-            let ts = ThemeSet::load_defaults();
-            SyntectHighlighter { ss, ts }
+            SyntectHighlighter {
+                ss: SyntaxSet::load_defaults_newlines(),
+                ts: ThemeSet::load_defaults(),
+            }
         }
     }
 
     impl Highlighter for SyntectHighlighter {
         fn hl_codeblock(&self, name: Option<&str>, block: &str) -> Vec<Event<'_>> {
             let syntax = name
-                .and_then(|name| self.ss.find_syntax_by_token(&name))
+                .and_then(|n| self.ss.find_syntax_by_token(n))
                 .unwrap_or_else(|| self.ss.find_syntax_plain_text());
 
-            // debug!("source name: {}, syntax: {:?}", name, syntax.name);
+            let mut generator =
+                ClassedHTMLGenerator::new_with_class_style(syntax, &self.ss, class_style());
+            for line in LinesWithEndings::from(block) {
+                if generator
+                    .parse_html_for_line_which_includes_newline(line)
+                    .is_err()
+                {
+                    return to_default_events(name, block);
+                }
+            }
+            let inner = generator.finalize();
+            let html = format!("<pre class=\"hl-code\"><code>{}</code></pre>\n", inner);
+            vec![Event::Html(html.into())]
+        }
 
-            let theme = &self.ts.themes["InspiredGitHub"];
-            let highlighted = highlighted_html_for_string(&block, &self.ss, &syntax, theme);
-            match highlighted {
-                Ok(html) => vec![Event::Html(html.into())],
-                Err(_) => to_default_events(name, &block),
+        fn write_header(&self, out: &mut dyn Write) -> std::io::Result<()> {
+            let io_err =
+                |e: syntect::Error| std::io::Error::new(std::io::ErrorKind::Other, e.to_string());
+            let light_css = strip_background_color(
+                &css_for_theme_with_class_style(&self.ts.themes[LIGHT_THEME], class_style())
+                    .map_err(io_err)?,
+            );
+            let dark_css = strip_background_color(
+                &css_for_theme_with_class_style(&self.ts.themes[DARK_THEME], class_style())
+                    .map_err(io_err)?,
+            );
+            let dark_prefixed =
+                prefix_css_selectors(&dark_css, "html[data-color-mode=\"dark\"]");
+            write!(
+                out,
+                "<style>\n{}\n@media (prefers-color-scheme: dark) {{\n{}}}\n{}</style>",
+                light_css, dark_css, dark_prefixed
+            )
+        }
+    }
+
+    /// Strip `background-color` declarations from generated theme CSS.
+    ///
+    /// This lets the design's own `pre` rule control the container background
+    /// consistently across light and dark modes.
+    fn strip_background_color(css: &str) -> String {
+        css.lines()
+            .filter(|line| !line.trim_start().starts_with("background-color"))
+            .map(|line| format!("{}\n", line))
+            .collect()
+    }
+
+    /// Prefix each CSS selector in `css` with `prefix`.
+    ///
+    /// Used to scope a theme's CSS under a manual dark-mode override selector.
+    fn prefix_css_selectors(css: &str, prefix: &str) -> String {
+        let mut result = String::new();
+        for chunk in css.split('}') {
+            let trimmed = chunk.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some(brace) = trimmed.find('{') {
+                let selector = trimmed[..brace].trim();
+                let props = trimmed[brace + 1..].trim();
+                result.push_str(&format!("{} {} {{\n    {}\n}}\n", prefix, selector, props));
             }
         }
-        fn write_header(&self, _out: &mut dyn Write) -> std::io::Result<()> {
-            Ok(())
-        }
+        result
     }
 }
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -101,13 +101,13 @@ mod syntect_hl {
                     &css_for_theme_with_class_style(&self.ts.themes[DARK_THEME], class_style())
                         .map_err(io_err)?,
                 );
-                let dark_auto =
+                let dark_system_preference =
                     prefix_css_selectors(&dark_css, "html:not([data-color-mode])");
                 let dark_prefixed =
                     prefix_css_selectors(&dark_css, "html[data-color-mode=\"dark\"]");
                 Ok(format!(
                     "<style>\n{}\n@media (prefers-color-scheme: dark) {{\n{}}}\n{}</style>",
-                    light_css, dark_auto, dark_prefixed
+                    light_css, dark_system_preference, dark_prefixed
                 ))
             })?;
             out.write_all(header.as_bytes())

--- a/src/render/layout/html.rs
+++ b/src/render/layout/html.rs
@@ -2,6 +2,7 @@ use crate::{
     asset::Asset,
     doctree::Page,
     error::Result,
+    highlight,
     render::{NavInfo, PageKind, RenderState},
     toc::{Nodes, Toc, TocElement},
 };
@@ -178,6 +179,11 @@ impl Layout for HtmlLayout {
     ) -> Result<()> {
         let nav_prefix = kind.path_to_bale();
         let root = state.path_to_root(&kind);
+        let hl_header = {
+            let mut buf = Vec::new();
+            let _ = highlight::get_hilighter().write_header(&mut buf);
+            String::from_utf8(buf).unwrap_or_default()
+        };
         write!(
             writer,
             r##"<!DOCTYPE html>
@@ -190,6 +196,7 @@ impl Layout for HtmlLayout {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat&family=JetBrains+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{root}style.css">
+    {hl_header}
     <script src="{root}dark.js" type=module></script>
     <script src="{root}search.js" type=module></script>
     <script src="{root}nav.js" type=module></script>
@@ -237,6 +244,7 @@ impl Layout for HtmlLayout {
 </html>"##,
             site_name = state.ctx().site_name,
             root = root,
+            hl_header = hl_header,
             breadcrumbs = Breadcrumbs(state, nav_prefix),
             page_title = page.title(),
             navs = Navs(&state.navs, nav_prefix, &root),

--- a/src/render/layout/html.rs
+++ b/src/render/layout/html.rs
@@ -181,8 +181,11 @@ impl Layout for HtmlLayout {
         let root = state.path_to_root(&kind);
         let hl_header = {
             let mut buf = Vec::new();
-            let _ = highlight::get_hilighter().write_header(&mut buf);
-            String::from_utf8(buf).unwrap_or_default()
+            highlight::get_hilighter().write_header(&mut buf)?;
+            match String::from_utf8(buf) {
+                Ok(s) => s,
+                Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
+            }
         };
         write!(
             writer,


### PR DESCRIPTION
Bring hightlighting up to date with the latest syntect, and strip background colors from the generated CSS so that it can be used in both light and dark modes without needing to generate separate CSS for each mode.